### PR TITLE
added q2 2019 layer to the map

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ const map = new mapboxgl.Map({
 map.on('load', function () {
   map.addSource('points', {
     type: 'geojson',
-    data: 'https://raw.githubusercontent.com/Open-Data-Tallahassee/vision-zero/main/crash-data/clean/all-2018to2021.geojson',
+    data: 'https://raw.githubusercontent.com/Open-Data-Tallahassee/vision-zero/main/crash-data/quarterly-tranches/leon-events-2019-q2.geojson',
     generateId: true
   });
   map.addLayer(


### PR DESCRIPTION
what happened:
- added q2 2019 layer to the map

what's next:
- figure out a way to filter crashes by type?